### PR TITLE
Added "passage:" macro that requires no arguments

### DIFF
--- a/.src/Cradle/StoryFormats/Harlowe/HarloweRuntimeMacros.cs
+++ b/.src/Cradle/StoryFormats/Harlowe/HarloweRuntimeMacros.cs
@@ -188,6 +188,16 @@ namespace Cradle.StoryFormats.Harlowe
         {
             return new HarloweArray(Story.PassageHistory.Select(passageName => new StoryVar(passageName)));
         }
+	
+	        [RuntimeMacro]
+        public StoryVar passage()
+        {
+	        return new HarloweDatamap(
+		        "source", "Cradle can't show the source of the passage.",
+		        "name", Story.CurrentPassage.Name,
+		        "tags", sorted(Story.CurrentPassage.Tags)
+	        );
+        }
 
 		[RuntimeMacro]
         public StoryVar passage(string passageName)


### PR DESCRIPTION
Per the Harlowe v1.2.4 manual entry for the "(passage: )" macro:
> If no name was provided, then it provides information about the current passage.

For example, `(set: $passage to (passage:)'s name)` should output the current passage's name.
The aforementioned code works in Twine, but results in the error "No overload for method 'passage' takes `0' arguments" in Unity Cradle.