### PR TITLE
quick fix on macro sample code documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,8 +401,9 @@ Here is a complete example that plays/stops an audio source:
 
 ```c#
 using UnityEngine;
+using Cradle;
 
-public SoundEffectsMacros: Cradle.RuntimeMacros
+public class SoundEffectsMacros: Cradle.RuntimeMacros
 {
 	[RuntimeMacro]
 	public void sfxPlay(string soundName)


### PR DESCRIPTION
The sample code will throw errors if used. The class declaration is missing and without a reference to the Cradle namespace the decorations will throw errors.